### PR TITLE
[ReUp] Update the copyright year in various files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MODX Revolution
 
-Copyright 2006-2016 by MODX, LLC.
+Copyright 2006-2018 by MODX, LLC.
 
 All rights reserved.
 

--- a/_build/docs/themes/modx/template.xml
+++ b/_build/docs/themes/modx/template.xml
@@ -2,7 +2,7 @@
 <template>
   <author>MODX CMF</author>
   <version>1.0</version>
-  <copyright>2011-2014 MODX, LLC</copyright>
+  <copyright>2011-2018 MODX, LLC</copyright>
   <transformations>
     <transformation query="copy" writer="FileIo" source="ajax_search.php" artifact="ajax_search.php"/>
     <transformation query="copy" writer="FileIo" source="js" artifact="js"/>

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -1,6 +1,6 @@
 /**
  * xtheme-modx
- * Copyright (c) 2009-2014, MODX, LLC
+ * Copyright (c) 2009-2018, MODX, LLC
  *
  * xtheme-modx is licensed under the terms of the GNU Open Source GPL 2.0
  * or later license.

--- a/_build/test/MODxControllerTestCase.php
+++ b/_build/test/MODxControllerTestCase.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Cases/Request/MakeUrlTest.php
+++ b/_build/test/Tests/Cases/Request/MakeUrlTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Controllers/Context/ContextListControllerTest.php
+++ b/_build/test/Tests/Controllers/Context/ContextListControllerTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Controllers/Context/ContextUpdateControllerTest.php
+++ b/_build/test/Tests/Controllers/Context/ContextUpdateControllerTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Controllers/WelcomeControllerTest.php
+++ b/_build/test/Tests/Controllers/WelcomeControllerTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modChunkTest.php
+++ b/_build/test/Tests/Model/Element/modChunkTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modElementTest.php
+++ b/_build/test/Tests/Model/Element/modElementTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modPluginTest.php
+++ b/_build/test/Tests/Model/Element/modPluginTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modSnippetTest.php
+++ b/_build/test/Tests/Model/Element/modSnippetTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modTagTest.php
+++ b/_build/test/Tests/Model/Element/modTagTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modTemplateTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element/modTemplateVarTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateVarTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element_todo/modFieldTagTest.php
+++ b/_build/test/Tests/Model/Element_todo/modFieldTagTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element_todo/modLexiconTagTest.php
+++ b/_build/test/Tests/Model/Element_todo/modLexiconTagTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element_todo/modLinkTagTest.php
+++ b/_build/test/Tests/Model/Element_todo/modLinkTagTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element_todo/modPlaceholderTagTest.php
+++ b/_build/test/Tests/Model/Element_todo/modPlaceholderTagTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Element_todo/modScriptTest.php
+++ b/_build/test/Tests/Model/Element_todo/modScriptTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Error/modErrorHandlerTest.php
+++ b/_build/test/Tests/Model/Error/modErrorHandlerTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Error/modErrorTest.php
+++ b/_build/test/Tests/Model/Error/modErrorTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -70,7 +70,7 @@ class modErrorTest extends MODxTestCase {
 
     /**
      * Ensures addField adds the correct message to the proper field
-     * 
+     *
      * @param string $field
      * @param string $message
      * @dataProvider providerTestAddField

--- a/_build/test/Tests/Model/Filters/modInputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modInputFilterTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Hashing/modHashingTest.php
+++ b/_build/test/Tests/Model/Hashing/modHashingTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Hashing/modMD5HashTest.php
+++ b/_build/test/Tests/Model/Hashing/modMD5HashTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Hashing/modPBKDF2HashTest.php
+++ b/_build/test/Tests/Model/Hashing/modPBKDF2HashTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Lexicon/modLexiconTest.php
+++ b/_build/test/Tests/Model/Lexicon/modLexiconTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Mail/modMailTest.php
+++ b/_build/test/Tests/Model/Mail/modMailTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Mail/modPHPMailerTest.php
+++ b/_build/test/Tests/Model/Mail/modPHPMailerTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/REST/modRestClientTest.php
+++ b/_build/test/Tests/Model/REST/modRestClientTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/REST/modRestCurlClientTest.php
+++ b/_build/test/Tests/Model/REST/modRestCurlClientTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/REST/modRestSockClientTest.php
+++ b/_build/test/Tests/Model/REST/modRestSockClientTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Registry/modDbRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modDbRegisterTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Registry/modFileRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modFileRegisterTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Registry/modRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modRegisterTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Registry/modRegistryTest.php
+++ b/_build/test/Tests/Model/Registry/modRegistryTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Resource/modResourceTest.php
+++ b/_build/test/Tests/Model/Resource/modResourceTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Resource/modStaticResourceTest.php
+++ b/_build/test/Tests/Model/Resource/modStaticResourceTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Resource/modSymLinkTest.php
+++ b/_build/test/Tests/Model/Resource/modSymLinkTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Resource/modWebLinkTest.php
+++ b/_build/test/Tests/Model/Resource/modWebLinkTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -54,7 +54,7 @@ class modUserTest extends MODxTestCase {
 
     /**
      * Test the overrides on xPDOObject::set for the user
-     * 
+     *
      * @param string $field
      * @param mixed $value
      * @param mixed $expected

--- a/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -54,7 +54,7 @@ class modFileMediaSourceTest extends MODxTestCase {
         parent::tearDown();
         $this->source = null;
     }
-    
+
     public function testInitialize() {
         $this->source->initialize();
 
@@ -76,7 +76,7 @@ class modFileMediaSourceTest extends MODxTestCase {
     public function testGetBasesWithEmptyPath() {
         $this->source->initialize();
         $bases = $this->source->getBases('');
-        
+
         $this->assertEquals('',$bases['path'],'Index "path" does not match expected.');
         $this->assertEquals(true,$bases['pathIsRelative'],'Index "pathIsRelative" does not match expected.');
         $this->assertEquals(MODX_BASE_PATH,$bases['pathAbsolute'],'Index "pathAbsolute" does not match expected.');

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -53,7 +53,7 @@ class modMediaSourceTest extends MODxTestCase {
         parent::tearDown();
         $this->source = null;
     }
-    
+
     public function testExample() {
         $this->assertTrue(true);
     }

--- a/_build/test/Tests/Model/Transport/modPackageBuilderTest.php
+++ b/_build/test/Tests/Model/Transport/modPackageBuilderTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Transport/modTransportManagerTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportManagerTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Transport/modTransportPackageTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportPackageTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Transport/modTransportProviderTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportProviderTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Transport/modTransportVehicleTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportVehicleTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/Validation/modValidatorTest.php
+++ b/_build/test/Tests/Model/Validation/modValidatorTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Browser/FileTest.php
+++ b/_build/test/Tests/Processors/Browser/FileTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -58,7 +58,7 @@ class BrowserFileProcessorsTest extends MODxTestCase {
      */
     public function providerGet() {
         return array(
-            array('manager/index.php'),  
+            array('manager/index.php'),
         );
     }
 }

--- a/_build/test/Tests/Processors/Context/ContextSettingTest.php
+++ b/_build/test/Tests/Processors/Context/ContextSettingTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Context/ContextTest.php
+++ b/_build/test/Tests/Processors/Context/ContextTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/PluginTest.php
+++ b/_build/test/Tests/Processors/Element/PluginTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/PropertySetTest.php
+++ b/_build/test/Tests/Processors/Element/PropertySetTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/SnippetTest.php
+++ b/_build/test/Tests/Processors/Element/SnippetTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/TemplateTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Element/TemplateVarTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateVarTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
+++ b/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/System/ActionTest.php
+++ b/_build/test/Tests/Processors/System/ActionTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/Processors/modProcessorTes-skip-t.php
+++ b/_build/test/Tests/Processors/modProcessorTes-skip-t.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -132,7 +132,7 @@ class modProcessorTest extends MODxTestCase {
 
     /**
      * Tests and ensures processors run correctly
-     * 
+     *
      * @param array $properties
      * @param boolean $success
      * @param string $message

--- a/_build/test/Tests/modXSetupTest.php
+++ b/_build/test/Tests/modXSetupTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/Tests/modXTeardownTest.php
+++ b/_build/test/Tests/modXTeardownTest.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/_build/test/properties.sample.inc.php
+++ b/_build/test/properties.sample.inc.php
@@ -2,7 +2,7 @@
 /**
  * MODX Revolution
  *
- * Copyright 2006-2014 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -2,7 +2,7 @@
 /*
  * MODX Revolution
  *
- * Copyright 2006-2012 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  *
  * All rights reserved.
  *

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -2,7 +2,7 @@
 /*
  * MODX Revolution
  *
- * Copyright 2006-2012 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  *
  * All rights reserved.
  *

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -2,7 +2,7 @@
 /*
  * MODX Revolution
  *
- * Copyright 2006-2012 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  *
  * All rights reserved.
  *

--- a/core/model/schema/modx.transport.mysql.schema.xml
+++ b/core/model/schema/modx.transport.mysql.schema.xml
@@ -2,7 +2,7 @@
 <!--
 /*
  * MODX CMS and PHP Application Framework ("MODX")
- * Copyright 2006, 2007, 2008 by MODX, LLC.
+ * Copyright 2006-2018 by MODX, LLC.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/setup/templates/base_template.tpl
+++ b/setup/templates/base_template.tpl
@@ -278,7 +278,7 @@
     </div>
 </div>
 <footer class="disclaimer">
-    <p>&copy; 2005-2016 the <a href="http://www.modx.com/" target="_blank">MODX</a> Content Management Framework (CMF) project. All rights reserved. MODX is licensed under the GNU&nbsp;GPL.</p>
+    <p>&copy; 2005-2018 the <a href="http://www.modx.com/" target="_blank">MODX</a> Content Management Framework (CMF) project. All rights reserved. MODX is licensed under the GNU&nbsp;GPL.</p>
 </footer>
 
 <script>


### PR DESCRIPTION
### What does it do?
Updates the copyright year to 2018 in various files where the copyright year is (still) present

### Why is it needed?
With a new major release it's a good idea to also update the copyright year.

### Related issue(s)/PR(s)
#13872
